### PR TITLE
feat(ui): add theme toggle and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.6.0](https://github.com/HsiehShuJeng/scott-edge-extensions/compare/v2.5.3...v2.6.0) (2025-05-30)
+
+
+### Features
+
+* **ui:** add theme toggle and persistent preferences ([4b65eb5](https://github.com/HsiehShuJeng/scott-edge-extensions/commit/4b65eb5b99ea80918746b6814b1883f1620960b5))
+* **ui:** extend extension to support Korean & commits ([707cea2](https://github.com/HsiehShuJeng/scott-edge-extensions/commit/707cea258a8e9ff77d4a95e1bd1649514f0b2649))
+
 ### [2.5.3](https://github.com/HsiehShuJeng/scott-edge-extensions/compare/v2.5.2...v2.5.3) (2025-05-30)
 
 ### [2.5.2](https://github.com/HsiehShuJeng/scott-edge-extensions/compare/v2.5.1...v2.5.2) (2025-05-30)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ A Chrome extension for English learners that generates optimized LLM prompts bas
    His ratings remain dismal, not least because of his cold, aloof manner and his eagerness to please the party.
 3. Multiple words with its context sentence
 
+## UI Features
+- **Theme Toggle**: Switch between light and dark modes using the sun/moon icon in the top-right corner
+- **Persistent Preferences**: Your theme preference is saved between sessions
+
 ## Loading into Edge
 1. Type `edge://extensions`
 2. Click the 'Reload' button

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - [Sequence Diagrams](#sequence-diagrams)
 - [Contributor Onboarding](#contributor-onboarding)
 
-This extension is for interacting with [ChatGPT](https://openai.com/blog/chatgpt) for learning English. There are 3 scenarios supported so far.
+A Chrome extension for English learners that generates optimized LLM prompts based on vocabulary words and their context sentences.
 
 ## Scenarios
 1. A single word

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - [Sequence Diagrams](#sequence-diagrams)
 - [Contributor Onboarding](#contributor-onboarding)
 
-A Chrome extension for English learners that generates optimized LLM prompts based on vocabulary words and their context sentences.
+A browser extension for language learners (English and Korean) and programmers, generating optimized LLM prompts for vocabulary in context and commit messages for code changes.
 
 ## Scenarios
 1. A single word

--- a/english-helper/manifest.json
+++ b/english-helper/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Asking Expert",
   "version": "2.5.2",
-  "description": "An English learning assistant that generates LLM prompts for vocabulary in context.",
+  "description": "An assistant for language learning (English and Korean) and programming, generating LLM prompts and commit messages.",
   "icons": {
     "48": "images/icon48.png"
   },
@@ -19,7 +19,8 @@
   "permissions": [
     "clipboardWrite",
     "activeTab",
-    "scripting"
+    "scripting",
+    "storage"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/english-helper/manifest.json
+++ b/english-helper/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Asking Expert",
   "version": "2.5.2",
-  "description": "An asking helper to generate a question as prompt for Vocabulary.com, Duolingo, and programming efforts.",
+  "description": "An English learning assistant that generates LLM prompts for vocabulary in context.",
   "icons": {
     "48": "images/icon48.png"
   },

--- a/english-helper/popup.html
+++ b/english-helper/popup.html
@@ -8,6 +8,7 @@
     <style>
         /* Variables */
         :root {
+            /* Light theme (default) */
             --main-padding: 10px;
             --main-color: #333;
             --background-color: #f9f9f9;
@@ -16,6 +17,21 @@
             --button-radius: 5px;
             --tooltip-width: 300px;
             --tooltip-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
+            --commit-tools-bg: linear-gradient(90deg, #4361ee, #4cc9f0, #7209b7);
+            --button-bg: #4CAF50;
+            --button-hover: #3e8e41;
+        }
+
+        .dark-theme {
+            /* Dark theme */
+            --main-color: #f0f0f0;
+            --background-color: #1e1e1e;
+            --highlight-color: #2e7d32;
+            --error-color: #ff6b6b;
+            --tooltip-shadow: 0px 0px 10px rgba(255, 255, 255, 0.1);
+            --commit-tools-bg: linear-gradient(90deg, #2a3a9c, #3a9ca6, #4a0a7d);
+            --button-bg: #2e7d32;
+            --button-hover: #1b5e20;
         }
 
         /* Global Styles */
@@ -190,6 +206,7 @@
 </head>
 
 <body>
+    <button id="theme-toggle">🌙</button>
     <div id="english-section">
         <h2>Scott's Assistant for English Learning</h2>
         <div class="activity-controls">
@@ -270,7 +287,7 @@
         flex-direction: row;
         justify-content: space-around;
         align-items: center;
-        background: linear-gradient(90deg, #4361ee, #4cc9f0, #7209b7);
+        background: var(--commit-tools-bg);
         border-radius: 12px;
         overflow: hidden;
         margin-bottom: 10px;

--- a/english-helper/popup.html
+++ b/english-helper/popup.html
@@ -44,6 +44,8 @@
             flex-direction: column;
             align-items: stretch;
             color: var(--main-color);
+            background-color: var(--background-color);
+            transition: background-color 0.3s ease, color 0.3s ease;
         }
 
         h2 {
@@ -202,12 +204,71 @@
             visibility: visible;
             opacity: 1;
         }
+
+        /* Theme Toggle Switch */
+        #theme-toggle-container {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            z-index: 10;
+        }
+
+        .toggle-switch {
+            display: block;
+            width: 60px;
+            height: 30px;
+            background: #ddd;
+            border-radius: 15px;
+            position: relative;
+            cursor: pointer;
+            transition: background 0.3s;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+
+        .toggle-switch:before {
+            content: '';
+            position: absolute;
+            width: 26px;
+            height: 26px;
+            border-radius: 50%;
+            background: white;
+            top: 2px;
+            left: 2px;
+            transition: transform 0.3s;
+        }
+
+        #theme-toggle:checked + .toggle-switch {
+            background: #4a0a7d;
+        }
+
+        #theme-toggle:checked + .toggle-switch:before {
+            transform: translateX(30px);
+        }
+
+        .sun, .moon {
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+            font-size: 16px;
+        }
+
+        .sun { left: 6px; }
+        .moon { right: 6px; }
+        #theme-toggle {
+            display: none;
+        }
     </style>
 </head>
 
 <body>
-    <button id="theme-toggle">🌙</button>
-    <div id="english-section">
+    <div id="theme-toggle-container">
+        <input type="checkbox" id="theme-toggle" hidden>
+        <label for="theme-toggle" class="toggle-switch">
+            <span class="sun">☀️</span>
+            <span class="moon">🌙</span>
+        </label>
+    </div>
+    <div id="english-section" style="background-color: inherit;">
         <h2>Scott's Assistant for English Learning</h2>
         <div class="activity-controls">
             <!-- Accessible button labels -->
@@ -242,7 +303,7 @@
             <button id="translate_en">Translate to English</button>
         </div>
     </div>
-    <div id="korean-section">
+    <div id="korean-section" style="background-color: inherit;">
         <h2>Scott's Assistant for Korean Learning</h2>
         <div class="activity-controls">
             <!-- Accessible button labels -->

--- a/english-helper/popup.js
+++ b/english-helper/popup.js
@@ -1,6 +1,26 @@
 import { initializeUI } from './ui.js';
 import { showNotification } from './utils.js';
 
+// Theme toggle functionality
+function setupThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    
+    // Load saved theme or default to light
+    chrome.storage.local.get('theme', (data) => {
+        const theme = data.theme || 'light';
+        document.body.classList.toggle('dark-theme', theme === 'dark');
+        themeToggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+    });
+
+    // Toggle theme on button click
+    themeToggle.addEventListener('click', () => {
+        const isDark = document.body.classList.toggle('dark-theme');
+        const theme = isDark ? 'dark' : 'light';
+        chrome.storage.local.set({ theme });
+        themeToggle.textContent = isDark ? '☀️' : '🌙';
+    });
+}
+
 // Add event listeners for commit buttons
 function setupCommitButtons() {
     const commitButtons = document.querySelectorAll('.commit-btn');
@@ -107,3 +127,4 @@ async function executeCommand(command) {
 
 initializeUI();
 setupCommitButtons();
+setupThemeToggle();

--- a/english-helper/popup.js
+++ b/english-helper/popup.js
@@ -8,16 +8,16 @@ function setupThemeToggle() {
     // Load saved theme or default to light
     chrome.storage.local.get('theme', (data) => {
         const theme = data.theme || 'light';
-        document.body.classList.toggle('dark-theme', theme === 'dark');
-        themeToggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+        const isDark = theme === 'dark';
+        document.body.classList.toggle('dark-theme', isDark);
+        themeToggle.checked = isDark;
     });
 
-    // Toggle theme on button click
-    themeToggle.addEventListener('click', () => {
-        const isDark = document.body.classList.toggle('dark-theme');
-        const theme = isDark ? 'dark' : 'light';
-        chrome.storage.local.set({ theme });
-        themeToggle.textContent = isDark ? '☀️' : '🌙';
+    // Toggle theme on switch change
+    themeToggle.addEventListener('change', () => {
+        const isDark = themeToggle.checked;
+        document.body.classList.toggle('dark-theme', isDark);
+        chrome.storage.local.set({ theme: isDark ? 'dark' : 'light' });
     });
 }
 

--- a/lesson_learned.md
+++ b/lesson_learned.md
@@ -1,7 +1,7 @@
 # Lessons Learned: Implementing Commit Message Generation
 
 ## Functional Overview
-This extension assists English learners by generating optimized LLM prompts for vocabulary:
+This extension assists language learners (English and Korean) by generating optimized LLM prompts for vocabulary, and programmers by generating commit messages:
 - Single word analysis
 - Word with context sentence
 - Multiple words with context

--- a/lesson_learned.md
+++ b/lesson_learned.md
@@ -1,5 +1,11 @@
 # Lessons Learned: Implementing Commit Message Generation
 
+## Functional Overview
+This extension assists English learners by generating optimized LLM prompts for vocabulary:
+- Single word analysis
+- Word with context sentence
+- Multiple words with context
+
 ## Technical Implementation
 1. **DOM Manipulation**: Added event listeners to new UI elements using `querySelectorAll` and `addEventListener`
 2. **Clipboard API**: Used `navigator.clipboard.writeText` for reliable text copying

--- a/lesson_learned.md
+++ b/lesson_learned.md
@@ -18,10 +18,12 @@ This extension assists English learners by generating optimized LLM prompts for 
    - Clear visual feedback through notifications
    - Consistent styling with existing UI elements
    - Intuitive button labeling
+   - Added theme toggle for improved readability in different lighting conditions
 2. **Maintainability**:
    - Centralized command generation logic
    - Separation of concerns between UI setup and business logic
    - Reuse of existing utility functions
+   - Persisted user preferences using chrome.storage API
 
 ## Best Practices
 1. **Extension Architecture**:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scott-edge-extensions",
-      "version": "2.5.3",
+      "version": "2.6.0",
       "license": "ISC",
       "devDependencies": {
         "commitizen": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "description": "This extension is for interacting with [ChatGPT](https://openai.com/blog/chatgpt) for learning English. There are 3 scenarios supported so far.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- bump extension version to 2.6.0 in package.json and lockfile

- enhance README with browser scope, UI features, and prompt/commit notes

- expand manifest.json description and add storage permission

- augment popup.html with theme switch markup and CSS variables

- implement setupThemeToggle in popup.js for persistence via storage

- update lesson_learned.md to reflect theme toggle and preferences