### PR TITLE
fix(watermark): resolve image format selection issue and release v2.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.30.1](///compare/v2.30.0...v2.30.1) (2026-02-04)
+
 ## [2.30.0](///compare/v2.29.0...v2.30.0) (2026-02-01)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.30.2](///compare/v2.30.1...v2.30.2) (2026-02-04)
+
+
+### Bug Fixes
+
+* resolve image format selection issue in watermark remover 34d160c
+
 ### [2.30.1](///compare/v2.30.0...v2.30.1) (2026-02-04)
 
 ## [2.30.0](///compare/v2.29.0...v2.30.0) (2026-02-01)

--- a/asking-expert/manifest.json
+++ b/asking-expert/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Asking Expert",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "description": "An assistant for language learning (English/Korean), programming workflows, YouTube quiz generation, and professional infographic prompts.",
   "icons": {
     "48": "images/icon48.png"

--- a/asking-expert/manifest.json
+++ b/asking-expert/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Asking Expert",
-  "version": "2.30.1",
+  "version": "2.30.2",
   "description": "An assistant for language learning (English/Korean), programming workflows, YouTube quiz generation, and professional infographic prompts.",
   "icons": {
     "48": "images/icon48.png"

--- a/asking-expert/watermark.js
+++ b/asking-expert/watermark.js
@@ -293,11 +293,19 @@ async function addWatermark(inputCanvas) {
 }
 
 
+// Setup download button with dynamic format reading
 function setupDownloadButton(canvas) {
-    const downloadBtn = document.getElementById('download-btn');
+    const oldBtn = document.getElementById('download-btn');
     const formatSelect = document.getElementById('format-select');
 
-    const updateDownloadLink = () => {
+    // Clone button to remove old listeners
+    const newBtn = oldBtn.cloneNode(true);
+    oldBtn.parentNode.replaceChild(newBtn, oldBtn);
+
+    newBtn.disabled = false;
+    
+    // Add single click listener that reads current state
+    newBtn.onclick = () => {
         const format = formatSelect.value;
         const quality = 0.92; // High quality for WebP/JPEG
 
@@ -319,21 +327,11 @@ function setupDownloadButton(canvas) {
             confirmName = `${name} (Unwatermarked)${ext}`;
         }
 
-        // Remove old listener
-        const newBtn = downloadBtn.cloneNode(true);
-        downloadBtn.parentNode.replaceChild(newBtn, downloadBtn);
-
-        newBtn.onclick = () => {
-            const link = document.createElement('a');
-            link.download = confirmName;
-            link.href = canvas.toDataURL(format, quality);
-            link.click();
-        };
-        newBtn.disabled = false;
+        const link = document.createElement('a');
+        link.download = confirmName;
+        link.href = canvas.toDataURL(format, quality);
+        link.click();
     };
-
-    updateDownloadLink();
-    formatSelect.onchange = updateDownloadLink;
 }
 
 // Event Listeners

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scott-edge-extensions",
-      "version": "2.30.0",
+      "version": "2.30.1",
       "license": "ISC",
       "devDependencies": {
         "commitizen": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.30.1",
+  "version": "2.30.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scott-edge-extensions",
-      "version": "2.30.1",
+      "version": "2.30.2",
       "license": "ISC",
       "devDependencies": {
         "commitizen": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "description": "This extension is for interacting with [ChatGPT](https://openai.com/blog/chatgpt) for learning English. There are 3 scenarios supported so far.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.30.1",
+  "version": "2.30.2",
   "description": "This extension is for interacting with [ChatGPT](https://openai.com/blog/chatgpt) for learning English. There are 3 scenarios supported so far.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes a bug in the watermark remover tool where the image format selection (JPG/PNG) was ignored, defaulting to WebP. It also includes the release of version 2.30.2.

Changes:
- Fix event listener logic in `watermark.js` to correctly capture user format selection.
- Bump version to 2.30.2 in `package.json`, `manifest.json`, and `package-lock.json`.
- Update `CHANGELOG.md`.

Fixes format selection issue in Watermark Remover.