### PR TITLE
refactor(watermark): remove redundant angle buttons and release v2.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.35.0](///compare/v2.34.0...v2.35.0) (2026-02-04)
+
+
+### Features
+
+* improve Watermark UI/UX with rotation, opacity controls and dark mode 1e1001d
+
 ## [2.34.0](https://github.com/HsiehShuJeng/scott-edge-extensions/compare/v2.33.0...v2.34.0) (2026-02-04)
 
 

--- a/asking-expert/manifest.json
+++ b/asking-expert/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Asking Expert",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "An assistant for language learning (English/Korean), programming workflows, YouTube quiz generation, and professional infographic prompts.",
   "icons": {
     "48": "images/icon48.png"

--- a/asking-expert/styles/watermark.css
+++ b/asking-expert/styles/watermark.css
@@ -441,24 +441,3 @@ h1 {
     height: auto;
     display: block;
 }
-
-.icon-btn {
-    background: none;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    padding: 0 8px;
-    cursor: pointer;
-    font-size: 0.8rem;
-    color: var(--text-color);
-    height: 30px;
-    /* match input height approx */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background-color 0.2s;
-}
-
-.icon-btn:hover {
-    background-color: rgba(66, 133, 244, 0.1);
-    border-color: var(--primary-color);
-}

--- a/asking-expert/watermark.html
+++ b/asking-expert/watermark.html
@@ -78,8 +78,6 @@
                                 <div class="dual-input">
                                     <input type="range" id="wm-angle-range" min="-180" max="180" step="1" value="45">
                                     <input type="number" id="wm-angle" value="45" step="5">
-                                    <button id="wm-angle-45" class="icon-btn" title="Set to 45°">45°</button>
-                                    <button id="wm-angle-neg-45" class="icon-btn" title="Set to -45°">-45°</button>
                                 </div>
                                 <div class="quick-actions">
                                     <button type="button" class="quick-btn" data-value="45">45°</button>

--- a/asking-expert/watermark.js
+++ b/asking-expert/watermark.js
@@ -501,24 +501,5 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initial state
     toggleWmSettings();
 
-    // Angle Buttons
-    const btn45 = document.getElementById('wm-angle-45');
-    const btnNeg45 = document.getElementById('wm-angle-neg-45');
-
-    if (btn45) {
-        btn45.addEventListener('click', () => {
-            document.getElementById('wm-angle').value = 45;
-            document.getElementById('wm-angle-range').value = 45;
-            reprocess();
-        });
-    }
-
-    if (btnNeg45) {
-        btnNeg45.addEventListener('click', () => {
-            document.getElementById('wm-angle').value = -45;
-            document.getElementById('wm-angle-range').value = -45;
-            reprocess();
-        });
-    }
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scott-edge-extensions",
-      "version": "2.34.0",
+      "version": "2.35.0",
       "license": "ISC",
       "devDependencies": {
         "commitizen": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "This extension is for interacting with [ChatGPT](https://openai.com/blog/chatgpt) for learning English. There are 3 scenarios supported so far.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Refactors the Watermark UI by removing redundant 45/-45 degree angle buttons and their associated code, as these are now covered by the quick actions group.

Also includes the release of v2.35.0.

Changes:
- Removed `wm-angle-45` and `wm-angle-neg-45` from HTML/JS.
- Removed `.icon-btn` styles.
- Bumped version to 2.35.0.