### PR TITLE
chore(ui): update watermark preview label and release v2.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.35.1](///compare/v2.35.0...v2.35.1) (2026-02-05)
+
 ## [2.35.0](///compare/v2.34.0...v2.35.0) (2026-02-04)
 
 

--- a/asking-expert/manifest.json
+++ b/asking-expert/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Asking Expert",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "description": "An assistant for language learning (English/Korean), programming workflows, YouTube quiz generation, and professional infographic prompts.",
   "icons": {
     "48": "images/icon48.png"

--- a/asking-expert/watermark.html
+++ b/asking-expert/watermark.html
@@ -131,7 +131,7 @@
                 </div>
             </div>
             <div class="preview-box">
-                <h3>Left Corner Polished</h3>
+                <h3>Right-bottom Corner Polished</h3>
                 <div id="processed-preview" class="image-container">
                     <!-- Processed image will be shown here -->
                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scott-edge-extensions",
-      "version": "2.35.0",
+      "version": "2.35.1",
       "license": "ISC",
       "devDependencies": {
         "commitizen": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "description": "This extension is for interacting with [ChatGPT](https://openai.com/blog/chatgpt) for learning English. There are 3 scenarios supported so far.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR updates the "Polished" image preview label in the watermark UI to accurately reflect the "Right-bottom Corner" positioning.

It also includes the release artifacts for v2.35.1.

Changes:
- Update `watermark.html` heading text.
- Bump version to 2.35.1 in package files and manifest.
- Update Changelog.