### PR TITLE
fix(watermark): lower detection threshold to 0.20 and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.35.3](///compare/v2.35.2...v2.35.3) (2026-02-05)
+
 ### [2.35.2](///compare/v2.35.1...v2.35.2) (2026-02-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.35.2](///compare/v2.35.1...v2.35.2) (2026-02-05)
+
+
+### Bug Fixes
+
+* **watermark:** lower detection threshold to 0.20 5e6e411
+
 ### [2.35.1](///compare/v2.35.0...v2.35.1) (2026-02-05)
 
 ## [2.35.0](///compare/v2.34.0...v2.35.0) (2026-02-04)

--- a/asking-expert/manifest.json
+++ b/asking-expert/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Asking Expert",
-  "version": "2.35.2",
+  "version": "2.35.3",
   "description": "An assistant for language learning (English/Korean), programming workflows, YouTube quiz generation, and professional infographic prompts.",
   "icons": {
     "48": "images/icon48.png"

--- a/asking-expert/manifest.json
+++ b/asking-expert/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Asking Expert",
-  "version": "2.35.1",
+  "version": "2.35.2",
   "description": "An assistant for language learning (English/Korean), programming workflows, YouTube quiz generation, and professional infographic prompts.",
   "icons": {
     "48": "images/icon48.png"

--- a/asking-expert/modules/watermark/watermarkEngine.js
+++ b/asking-expert/modules/watermark/watermarkEngine.js
@@ -187,7 +187,8 @@ export class WatermarkEngine {
         // 0.3 is a conservative threshold (weak but matching). 
         // 0.5 is moderate.
         // Gemini watermark is quite strong, usually > 0.6.
-        return correlation > 0.35;
+        // Update: lowered to 0.20 based on user report (score 0.21) while clean images are ~0.01.
+        return correlation > 0.20;
     }
 
     /**

--- a/doc/gemini-watermark-removal.md
+++ b/doc/gemini-watermark-removal.md
@@ -32,7 +32,7 @@ The implementation involves several steps handled by the `WatermarkEngine`:
     -   Before attempting removal, the tool verifies if the watermark is actually present.
     -   It calculates the **Pearson Correlation Coefficient** between the image's pixel brightness and the watermark's alpha map.
     -   **Why Correlation?** Simple brightness checks fail on clean white images (false positives). Correlation statistically checks if the *variations* in pixel brightness match the specific *shape* of the watermark logo.
-    -   If the correlation is positive (> 0.35), the watermark is confirmed and removed.
+    -   If the correlation is positive (> 0.20), the watermark is confirmed and removed.
     -   If not, the image is left untouched (preventing "black watermark" artifacts on clean images).
 
 3.  **Alpha Map Loading**:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.35.2",
+  "version": "2.35.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scott-edge-extensions",
-      "version": "2.35.2",
+      "version": "2.35.3",
       "license": "ISC",
       "devDependencies": {
         "commitizen": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.35.1",
+  "version": "2.35.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scott-edge-extensions",
-      "version": "2.35.1",
+      "version": "2.35.2",
       "license": "ISC",
       "devDependencies": {
         "commitizen": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.35.1",
+  "version": "2.35.2",
   "description": "This extension is for interacting with [ChatGPT](https://openai.com/blog/chatgpt) for learning English. There are 3 scenarios supported so far.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scott-edge-extensions",
-  "version": "2.35.2",
+  "version": "2.35.3",
   "description": "This extension is for interacting with [ChatGPT](https://openai.com/blog/chatgpt) for learning English. There are 3 scenarios supported so far.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
This PR lowers the Pearson Correlation threshold for Gemini watermark detection from 0.35 to 0.20. This adjustment is based on user reports where legitimate watermarks were being missed (score ~0.21), while clean images typically score around 0.01.

## Changes
- **watermark Engine**: Updated `correlation > 0.20` threshold in `watermarkEngine.js`.
- **Documentation**: Updated `doc/gemini-watermark-removal.md` to reflect the new threshold.
- **Release**: Version bumped to 2.35.3 with `manifest.json` sync.

## Verification
- Verified the threshold change internally.
- Documentation matches the implementation.
