### PR TITLE
fix(watermark): dynamically detect configuration sizes and update bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.2.7](///compare/v3.2.6...v3.2.7) (2026-02-22)
+
+
+### Bug Fixes
+
+* **watermark:** adjust threshold limits and fix race condition in UI listeners e462e99
+
 ### [3.2.6](///compare/v3.2.4...v3.2.6) (2026-02-21)
 
 ### [3.2.5](///compare/v3.2.4...v3.2.5) (2026-02-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.2.9](///compare/v3.2.8...v3.2.9) (2026-02-22)
+
 ### [3.2.8](///compare/v3.2.7...v3.2.8) (2026-02-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.2.8](///compare/v3.2.7...v3.2.8) (2026-02-22)
+
+
+### Bug Fixes
+
+* **watermark:** dynamically fallback to 96x96 mask size for sub-1024px images 424ad1a
+
 ### [3.2.7](///compare/v3.2.6...v3.2.7) (2026-02-22)
 
 

--- a/asking-expert/manifest.json
+++ b/asking-expert/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Asking Expert",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "An assistant for language learning (English/Korean), programming workflows, YouTube quiz generation, and professional infographic prompts.",
   "icons": {
     "48": "images/icon48.png"

--- a/asking-expert/manifest.json
+++ b/asking-expert/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Asking Expert",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "An assistant for language learning (English/Korean), programming workflows, YouTube quiz generation, and professional infographic prompts.",
   "icons": {
     "48": "images/icon48.png"

--- a/asking-expert/manifest.json
+++ b/asking-expert/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Asking Expert",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "An assistant for language learning (English/Korean), programming workflows, YouTube quiz generation, and professional infographic prompts.",
   "icons": {
     "48": "images/icon48.png"

--- a/asking-expert/watermark.html
+++ b/asking-expert/watermark.html
@@ -63,9 +63,9 @@
                             data-tooltip="Adjust sensitivity for watermark detection. Lower = more sensitive.">Detection
                             Threshold:</label>
                         <div class="dual-input">
-                            <input type="range" id="detection-threshold-range" min="1" max="50" step="1" value="10">
+                            <input type="range" id="detection-threshold-range" min="-10" max="50" step="1" value="10">
                             <div class="input-wrapper">
-                                <input type="number" id="detection-threshold" value="0.10" min="0.01" max="0.50"
+                                <input type="number" id="detection-threshold" value="0.10" min="-0.10" max="0.50"
                                     step="0.01">
                             </div>
                         </div>

--- a/asking-expert/watermark.js
+++ b/asking-expert/watermark.js
@@ -907,7 +907,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     syncRange('detection-threshold-range', 'detection-threshold',
         v => (v / 100).toFixed(2),
-        v => Math.round(parseFloat(v) * 100)
+        v => Math.round(parseFloat(v) * 100),
+        true // mark as full update
     );
 
     const thresholdInput = document.getElementById('detection-threshold');
@@ -922,13 +923,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    const thresholdRange = document.getElementById('detection-threshold-range');
-    if (thresholdRange) {
-        thresholdRange.addEventListener('input', reprocessFull);
-    }
-    if (thresholdInput) {
-        thresholdInput.addEventListener('input', reprocessFull);
-    }
+
 
     // Radio button changes to automatically update text and toggle settings opacity
     const modeRadios = document.querySelectorAll('input[name="processing-mode"]');

--- a/docs/gemini-watermark-removal.md
+++ b/docs/gemini-watermark-removal.md
@@ -24,9 +24,8 @@ $$ Original = \frac{Watermarked - \alpha \times Logo}{1 - \alpha} $$
 The implementation involves several steps handled by the `WatermarkEngine`:
 
 1.  **Configuration Detection**:
-    -   The tool checks the input image dimensions.
-    -   If dimensions are > 1024x1024, it assumes a **96x96px** watermark.
-    -   Otherwise, it uses a **48x48px** watermark.
+    -   The tool dynamically checks for both possible Gemini watermark sizes (**96x96px** and **48x48px**).
+    -   Instead of strictly relying on image dimensions, it tests both configurations and selects the one with the highest correlation to the image data.
 
 2.  **Smart Detection (Pearson Correlation)**:
     -   Before attempting removal, the tool verifies if the watermark is actually present.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scott-edge-extensions",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scott-edge-extensions",
-      "version": "3.2.8",
+      "version": "3.2.9",
       "license": "ISC",
       "dependencies": {
         "express": "^5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scott-edge-extensions",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scott-edge-extensions",
-      "version": "3.2.6",
+      "version": "3.2.7",
       "license": "ISC",
       "dependencies": {
         "express": "^5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scott-edge-extensions",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scott-edge-extensions",
-      "version": "3.2.7",
+      "version": "3.2.8",
       "license": "ISC",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scott-edge-extensions",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "This extension is for interacting with [ChatGPT](https://openai.com/blog/chatgpt) for learning English. There are 3 scenarios supported so far.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scott-edge-extensions",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "This extension is for interacting with [ChatGPT](https://openai.com/blog/chatgpt) for learning English. There are 3 scenarios supported so far.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scott-edge-extensions",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "This extension is for interacting with [ChatGPT](https://openai.com/blog/chatgpt) for learning English. There are 3 scenarios supported so far.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR addresses issues with Gemini watermark removal failing on images with dimensions under 1024px (e.g. 768x1376) but still containing a 96x96 watermark.

Key changes:
- Refactored `detectWatermarkConfig` in `watermarkEngine.js` to return both 48x48 and 96x96 watermark configurations instead of strict bounds checking.
- Updated `detectWatermark` to evaluate correlation for all possible configurations and dynamically use the highest correlation.
- Decreased the minimum allowed value for detection threshold inputs from `0.01` to `-0.10` to allow forceful removals of stubborn watermarks.
- Cleaned up duplicate event listeners in `watermark.js` that caused race conditions bypassing `removeWatermarkFromImage`.
- Updated documentation in `docs/gemini-watermark-removal.md` regarding the smart detection mechanism.
- Handled package version bumps via the release process (v3.2.9).